### PR TITLE
Updated main.js, DefinitionList.js: 

### DIFF
--- a/src/components/DefinitionList.js
+++ b/src/components/DefinitionList.js
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 
-const DefinitionList = ({ definition }) => {
+const DefinitionList = ({ definition, display }) => {
   // Check if error exists
   const error = definition?.[0]?.error;
   // get the word for display
@@ -69,7 +69,7 @@ const DefinitionList = ({ definition }) => {
 
   return (
     <>
-      {error ? (
+      {display? (error? (
         // display the error if error exists
         <div className="my-6 py-6">
           <div className="mx-4 md:mx-auto">
@@ -128,6 +128,14 @@ const DefinitionList = ({ definition }) => {
             </ul>
           </section>
         )
+      )): (
+        <div className="my-6 py-6">
+          <div className="mx-4 md:mx-auto">
+            <h2 className="text-xl md:text-3xl text-gray-500">
+              Please enter a word and search for the information and generate a relative image.
+            </h2>
+          </div>
+        </div>
       )}
     </>
   );

--- a/src/components/main.js
+++ b/src/components/main.js
@@ -14,10 +14,17 @@ function Main() {
   // states declarations to store data between rendering
   const [word, setWord] = useState("");
   const [fetchData, setFetchData] = useState([]);
+  const [definitionListDisplay, setDefinitionListDisplay] = useState(false);
   //Update word useState hook, everytime userinput
 
   function handleWord(e) {
     setWord(e.target.value);
+    // if (e.target.value === "" && e.key === "Enter") {
+    //   setDefinitionListDisplay(false);
+    // }
+    if (e.target.value === "") {
+      setDefinitionListDisplay(false);
+    }
   }
   // When Search button is click, fetch data from free dictionary api of the word in the form.
   // Save the definition fetched into fetch data useState hook
@@ -25,11 +32,16 @@ function Main() {
 
   const wordSubmit = async (e) => {
     e.preventDefault();
-    console.log(word);
+    // version 2 of empty input field
+    // if (word === "") {
+    //   setDefinitionListDisplay(false);
+    // } else {
+      console.log(word);
     await axios
       .get("https://api.dictionaryapi.dev/api/v2/entries/en/" + word)
       .then((res) => {
         setFetchData(res.data);
+        setDefinitionListDisplay(true);
       })
       .catch((error) => {
         console.error(
@@ -38,7 +50,10 @@ function Main() {
         );
         // set error message if word not found
         setFetchData([{ error: "Word not found" }]);
+        setDefinitionListDisplay(true);
       });
+      // version 2 of empty input field
+    // }
   };
   // re-render the page when word definition is updated
   // let result;
@@ -56,7 +71,7 @@ function Main() {
         handleWord={handleWord}
         wordSubmit={wordSubmit}
       />
-      <DefinitionList definition={fetchData} />
+      <DefinitionList definition={fetchData} display={definitionListDisplay}/>
       <Contact />
       <Footer />
     </>


### PR DESCRIPTION
created 2 versions of making definition list disappear with an empty input after a search.

![Screenshot 2024-03-20 at 12 28 24 AM](https://github.com/RileyC9/EasyGrammar/assets/148201048/75b0228c-e47a-48e0-81a1-d24f7af08292)

In the DefinitionList branch, input in the text field is required and it is preventing submit action.
The error message has appear as above.

I have made 2 version of making the definition list disappear with an empty input after a search.

1. the first one is the code I pushed now. If the user delete all the text in the search input field, the "Please enter a word and search for the information and generate a relative image." will appear. This will also appear when the user enter the page.
2. the second version is achieved by deleting the required parameter in the text input field. So when user search with an empty input, the "Please enter a word and search for the information and generate a relative image." will appear. However, the "Please fill out this field." message will not appear in this version.

I personally prefer the first version because it points to the area where user input is needed. And the message placed in the definition list can give the user a bit more instruction on how to use our website. The side effect is if the user delete the word in word search by accident, the definition listed before this action will be gone and the user will have to search for the word again.

Please advice which version should we implement, or there is some other way to work around the problem. Thank you all.